### PR TITLE
fixed: TypeError: Boom.wrap is not a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ class Hapify {
                     const result = Joi.validate(value, s, self._options.joi);
 
                     if (result.error) {
-                        return res.boom(Boom.wrap(result.error, 400));
+                        return res.boom(Boom.badRequest(result.error, 400));
                     }
                 }
             }


### PR DESCRIPTION
There were breaking changes in Boom v7.1.0 and they remove wrap function.